### PR TITLE
01_dependencies: add workspaces_DefaultRole IAM role

### DIFF
--- a/01_dependencies/iam.tf
+++ b/01_dependencies/iam.tf
@@ -1,0 +1,25 @@
+data "aws_iam_policy_document" "workspace_default_trust" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["workspaces.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "workspace_default" {
+  name               = "workspaces_DefaultRole"
+  assume_role_policy = data.aws_iam_policy_document.workspace_default_trust.json
+}
+
+resource "aws_iam_role_policy_attachment" "workspace_access" {
+  role       = aws_iam_role.workspace_default.id
+  policy_arn = "arn:aws:iam::aws:policy/AmazonWorkSpacesServiceAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "workspace_self_service_access" {
+  role       = aws_iam_role.workspace_default.id
+  policy_arn = "arn:aws:iam::aws:policy/AmazonWorkSpacesSelfServiceAccess"
+}

--- a/01_dependencies/main.tf
+++ b/01_dependencies/main.tf
@@ -71,6 +71,8 @@ resource "aws_workspaces_directory" "directory" {
   }
 
   tags = local.tags
+
+  depends_on = [aws_iam_role.workspace_default]
 }
 
 module "vpc" {


### PR DESCRIPTION
This is required to register an AWS WorkSpace directory.